### PR TITLE
give workers a unique name

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -40,14 +40,10 @@ class Client {
   /**
    * Get a Queue object for the given queue name
    */
-  queue(name) {
-    // TODO: still not sure if we want to make all workers under one process have the same workerName.
-    // Seems like they would just step on each other as they are independent (e.g., two workers working
-    // on the same job and renewing each other's lock/lease on the job). This seems to be what the
-    // Python ForkingWorker does, but perhaps they are not so independent under that model? Still it seems
-    // possible that two workers could be working on the same job and there is no check to see if this is
-    // happenning?
-    return new queue.Queue(name, this, this.workerName);
+  queue(name, workerNameSuffix) {
+    let workerName = this.workerName;
+    if (workerNameSuffix) workerName += '-' + workerNameSuffix.toString();
+    return new queue.Queue(name, this, workerName);
   }
 }
 

--- a/lib/workers/serial.js
+++ b/lib/workers/serial.js
@@ -13,11 +13,15 @@ const errors = require('../errors');
 const logger = util.logger('worker');
 
 const DEFAULT_INTERVAL = 5000; // ms
+
+let nWorkersThisProcess = 0;
+
 class Worker { // when have other kinds of workers, can move to a different file
   constructor(queueName, client, options) {
     this.client = client;
+    this.workerNumber = ++nWorkersThisProcess;
     // TODO: multiple queues this.queues = queueNames.map(name => client.queue(name));
-    this.queue = client.queue(queueName);
+    this.queue = client.queue(queueName, this.workerNumber);
     this.options = options || {};
     this.options.interval = this.options.interval || DEFAULT_INTERVAL;
   }


### PR DESCRIPTION
@dlecocq, see my comment removed here. I am wondering whether usernames should be unique to the process or to the worker if we have multiple workers. Unique to the worker would make the most sense to me, but seems not to be done in the Python client.

another way to handle worker names

will add a spec when i get validation from dan

@younker @erinren @tony-bye 
