### PR TITLE
Use https to link submodules to support anonymous builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "qless-core"]
 	path = qless-core
-	url = git@github.com:seomoz/qless-core
+	url = https://github.com/seomoz/qless-core.git


### PR DESCRIPTION
Support `submodule init` and `npm run build` in build environments without pre-installed ssh keys. Fixes #5