### PR TITLE
Add heartbeatUntilPromise to make it easy to keep a job lock.

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -206,6 +206,34 @@ class Job {
       });
   }
 
+  /**
+   * Heartbeat as needed, until a promise resolves.
+   *
+   * Before the job lock is lost, the heartbeat is run. The padding controls how long
+   * (in seconds) before the job lock loss to run the heartbeat. The default value is
+   * 10, meaning that the heartbeat will run 10 seconds before the lock is set to
+   * expire.
+   */
+  heartbeatUntilPromise(promise, padding) {
+    // The promise is wrapped in Bluebird to ensure it adheres to the expected API
+    const wrappedPromise = Promise.resolve(promise);
+    // Default to 10 seconds
+    padding = padding || 10;
+
+    const poll = () => {
+      // Heartbeat when `padding` seconds remain (converted to milliseconds)
+      const interval = (this.getTtl() - padding) * 1000;
+      return wrappedPromise.timeout(interval).catch(() => {
+        if (wrappedPromise.isPending()) {
+          return this.heartbeat().then(poll);
+        }
+        return wrappedPromise;
+      });
+    };
+
+    return poll();
+  }
+
   fail(group, message) {
     logger.info('Failing job %s in group %s', this.jid, group);
     return this.client.call(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",


### PR DESCRIPTION
@evanbattaglia @b4hand - I was sitting down to write this bit of functionality for my own project, but thought it'd be useful here, too.

This introduces `job.heartbeatUntilPromise`, which allows users to provide a promise and until that promise resolves, the job will heartbeat as needed.

```javascript
class MyJobClass {
  static queue(job) {
    // Promise that describes the real work of my job
    const realWork = ...;

    // Even if the real work takes a long time, we don't lose our lock
    return job.heartbeatUntilPromise(realWork)
      .then(() => job.complete());
  }
}
```