### PR TITLE
Update qless-core submodule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",


### PR DESCRIPTION
In service of getting qless.lua and qless-lib.lua in the npm package, qless-core needed a .npmignore in that repo.

Related to https://github.com/seomoz/qless-core/pull/71 - will need to rebase when that lands

@evanbattaglia @b4hand @benkirzhner 