### PR TITLE
Gracefully handle `job.process` failures

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -156,7 +156,8 @@ class Job {
         const message = error.stack;
         logger.error('Job %s failed in group %s', this.jid, group, error);
         return this.fail(group, message);
-      });
+      })
+      .catch(error => logger.error('Failed to fail job %s', this.jid, error));
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",


### PR DESCRIPTION
We've encountered an issue whereby our worker dies if the call to `job.fail` from within `job.process` fails.

There are a couple ways to solve that problem, and I think this is the best compromise. Ideally, the `worker`s themselves (`single` and `multi`) would handle the case where `job.process` rejects. However, my main concerns with that are that 1) each worker implementation has to be responsible for knowing about this quirk and 2) writing the corresponding test for each worker reaches pretty far deep into the implementation of `Job`.

This approach puts that burden on `job.process` directly. I do not like the fact that this has `job.process` swallow any error from `fail`, but in practice, I believe the only reasonable place where `job.process` gets called is from the workers anyway. I did think about having two varieties of `process` functions (say `processCatch` or `process`), but that seemed kind of clunky and unnecessary given the fact that just the workers use them, really.

@b4hand @evanbattaglia @kq2

