### PR TITLE
Provide `QlessError`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@ const Queue = require('./queue.js');
 const Job = require('./job.js');
 const logger = require('./logger.js');
 const Jobs = require('./jobs.js');
+const QlessError = require('./errors.js').QlessError;
 
 Promise.promisifyAll(fs);
 Promise.promisifyAll(redis.RedisClient.prototype);
@@ -53,6 +54,9 @@ class Client {
       .then((response) => {
         logger.debug('Response: %s', response);
         return response;
+      })
+      .catch((err) => {
+        throw new QlessError(err);
       });
   }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const util = require('util');
+
+const ExtendableError = require('es6-error');
+
+/**
+ * The top-level class for all of our errors.
+ */
+function QlessError() { }
+
+util.inherits(QlessError, ExtendableError);
+
+module.exports = {
+  QlessError,
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bluebird": "^3.5.0",
     "commander": "^2.9.0",
     "double-ended-queue": "^2.1.0-0",
+    "es6-error": "^4.0.2",
     "json-stable-stringify": "^1.0.1",
     "redis": "^2.7.1",
     "uuid": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -5,6 +5,7 @@ const Promise = require('bluebird');
 const expect = require('expect.js');
 const Client = require('../lib/client.js');
 const helper = require('./helper.js');
+const QlessError = require('../lib/errors.js').QlessError;
 
 describe('Qless client', () => {
   const url = process.env.REDIS_URL;
@@ -20,6 +21,11 @@ describe('Qless client', () => {
   it('can invoke call', () => {
     return client.call('tag', 'top', 0, 100)
       .then(response => expect(response).to.be('{}'));
+  });
+
+  it('wraps errors in QlessError', () => {
+    return client.call('complete', 'jid')
+      .catch(err => expect(err).to.be.a(QlessError));
   });
 
   it('memoizes SHA', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,6 +636,10 @@ es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-iterator "2"
     es6-symbol "~3.1"
 
+es6-error@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
+
 es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"


### PR DESCRIPTION
@b4hand @evanbattaglia @kq2

We've been having trouble differentiating errors that come from `qless` invocations from those that come from our code. So it'd be handy to have `qless` throw only `QlessError`s.