### PR TITLE
Add a forking worker

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const Client = require('./lib/client.js');
 const Single = require('./lib/workers/single.js');
 const Multi = require('./lib/workers/multi.js');
+const Forking = require('./lib/workers/forking.js');
 const logger = require('./lib/logger.js');
 
 module.exports = {
@@ -9,5 +10,6 @@ module.exports = {
   workers: {
     Single,
     Multi,
+    Forking,
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -15,7 +15,16 @@ const asArray = (obj) => {
   return isEmpty(obj) ? [] : obj;
 };
 
+/**
+ * Deep copy an object. This is not particularly efficient, and relies on JSON
+ * serialization.
+ */
+const deepCopy = (obj) => {
+  return JSON.parse(JSON.stringify(obj));
+};
+
 module.exports = {
   isEmpty,
   asArray,
+  deepCopy,
 };

--- a/lib/workers/forking-workerpool.js
+++ b/lib/workers/forking-workerpool.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const workerpool = require('workerpool');
+const Worker = require('./multi.js');
+
+const work = (config) => {
+  const worker = new Worker(config);
+
+  // This is necessary to ensure that when the parent process dies, that the
+  // child processes in turn die as well
+  process.on('disconnect', () => process.exit(0));
+
+  process.on('SIGQUIT', () => worker.stop());
+
+  return worker.run();
+};
+
+workerpool.worker({
+  work,
+});

--- a/lib/workers/forking.js
+++ b/lib/workers/forking.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const Path = require('path');
+
+const Promise = require('bluebird').Promise;
+const workerpool = require('workerpool');
+
+const logger = require('../logger.js');
+const deepCopy = require('../util.js').deepCopy;
+
+/**
+ * Worker that spawns multiple subprocesses, each running a Multi worker. This
+ * uses the `workerpool` module to manage all the subprocesses and respawning,
+ * but it does not use `workerpool` for delegating tasks to each worker.
+ */
+class Worker {
+
+  constructor(config) {
+    this.processes = config.processes;
+    this.pool = workerpool.pool(Path.resolve(__dirname, 'forking-workerpool.js'), {
+      minWorkers: this.processes,
+      maxWorkers: this.processes,
+    });
+    this.config = config;
+    this.stopped = false;
+  }
+
+  /**
+   * Stop the worker.
+   *
+   * If `force` is provided, workers should be terminated immediately. Otherwise,
+   * workers will finish the jobs they have in progress.
+   */
+  stop(force) {
+    this.stopped = true;
+    if (force) {
+      logger.warn('Forcefully terminating workers...');
+      return this.pool.terminate(true);
+    } else {
+      logger.info('Gracefully terminating workers...');
+      // This sends a signal indicating that the `Multi` worker in each process
+      // should not take on any more jobs.
+      this.pool.workers.forEach(worker => process.kill(worker.worker.pid, 'SIGQUIT'));
+      return this.pool.terminate(false);
+    }
+  }
+
+  /**
+   * Process jobs.
+   *
+   * Returns a promise that resolves when the worker is stopped. Throws when there
+   * is an unrecoverable exception.
+   */
+  run() {
+    const workForever = (id) => {
+      logger.info('Starting worker %s', id);
+
+      const config = deepCopy(this.config);
+
+      if (this.stopped) {
+        return id;
+      }
+
+      return this.pool.exec('work', [config])
+        .then(() => {
+          logger.info('Worker %s exited gracefully', id);
+          return id;
+        })
+        .catch((error) => {
+          logger.error('Worker %s died...', id, error);
+          return workForever(id);
+        });
+    };
+
+    const ids = Array.from(Array(this.processes).keys());
+
+    // offload a function to a worker
+    return Promise.map(ids, workForever)
+      .then(() => logger.info('All workers finished'))
+      .then(() => this.pool.terminate());
+  }
+
+}
+
+module.exports = Worker;

--- a/lib/workers/multi.js
+++ b/lib/workers/multi.js
@@ -3,17 +3,18 @@
 const Promise = require('bluebird').Promise;
 const Popper = require('./popper.js');
 const Semaphore = require('./semaphore.js');
+const Client = require('../client.js');
 
 /**
  * Worker that runs multiple concurrent jobs.
  */
 class Worker {
 
-  constructor(client, config) {
-    this.client = client;
-    const queues = config.queues;
+  constructor(config) {
+    this.client = config.client || new Client(config.clientConfig);
+    const queues = config.queues || config.queueNames.map(name => this.client.queue(name));
     this.interval = config.interval || 60000;
-    this.popper = new Popper(client, queues);
+    this.popper = new Popper(this.client, queues);
     this.processConfig = config.processConfig;
     this.semaphore = new Semaphore(config.count);
     this.running = new Set();

--- a/lib/workers/single.js
+++ b/lib/workers/single.js
@@ -1,14 +1,15 @@
 'use strict';
 
 const Popper = require('./popper.js');
+const Client = require('../client.js');
 
 class Worker {
 
-  constructor(client, config) {
-    this.client = client;
-    const queues = config.queues;
+  constructor(config) {
+    this.client = config.client || new Client(config.clientConfig);
+    const queues = config.queues || config.queueNames.map(name => this.client.queue(name));
     this.interval = config.interval || 60000;
-    this.popper = new Popper(client, queues);
+    this.popper = new Popper(this.client, queues);
     this.processConfig = config.processConfig;
   }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "json-stable-stringify": "^1.0.1",
     "redis": "^2.7.1",
     "uuid": "^3.0.1",
-    "winston": "^2.3.1"
+    "winston": "^2.3.1",
+    "workerpool": "^2.3.0"
   },
   "devDependencies": {
     "babel-core": "^6.20.0",
@@ -64,7 +65,9 @@
       "!index.js",
       "!**/node_modules/**",
       "!coverage/**",
-      "!test/helper.js"
+      "!test/helper.js",
+      "!test/workers/job.js",
+      "!lib/workers/forking-workerpool.js"
     ],
     "coverageThreshold": {
       "global": {
@@ -73,6 +76,7 @@
         "lines": 100,
         "statements": 100
       }
-    }
+    },
+    "testEnvironment": "node"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -22,3 +22,26 @@ describe('asArray', () => {
     expect(util.asArray([1, 2, 3])).to.eql([1, 2, 3]);
   });
 });
+
+describe('deepCopy', () => {
+  const obj = {
+    foo: {
+      bar: {
+        whiz: 5,
+      },
+    },
+  };
+
+  it('provides an identical copy', () => {
+    const copy = util.deepCopy(obj);
+
+    expect(copy).to.eql(obj);
+  });
+
+  it('provides a new object', () => {
+    const copy = util.deepCopy(obj);
+
+    delete copy.foo.bar.whiz;
+    expect(copy).not.to.eql(obj);
+  });
+});

--- a/test/workers/forking.test.js
+++ b/test/workers/forking.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const Path = require('path');
+
+const Promise = require('bluebird').Promise;
+const expect = require('expect.js');
+
+const helper = require('../helper.js');
+const Client = require('../../lib/client.js');
+const Worker = require('../../lib/workers/forking.js');
+
+describe('Forking Worker', () => {
+  const interval = 100;
+  const capacity = 10;
+  const url = process.env.REDIS_URL;
+  const client = new Client(url);
+  const cleaner = new helper.Cleaner(client);
+  const queue = client.queue('queue');
+  let worker = null;
+
+  beforeEach(() => {
+    worker = new Worker({
+      clientConfig: {
+        url,
+      },
+      queueNames: ['queue'],
+      processConfig: {
+        allowPaths: true,
+      },
+      interval,
+      count: capacity,
+      processes: 2,
+    });
+    return cleaner.before();
+  });
+
+  afterEach(() => cleaner.after());
+
+  afterEach(() => worker.stop(true));
+
+  afterAll(() => client.quit());
+
+  it('can run jobs', () => {
+    const klass = Path.resolve(__dirname, 'job/BasicJob');
+    const jid = 'jid';
+
+    return queue.put({ klass, jid })
+      .then(() => {
+        const poll = () => {
+          return client.job(jid)
+            .then((job) => {
+              if (job.state === 'failed' || job.state === 'complete') {
+                worker.stop();
+                return job.state;
+              }
+              return Promise.delay(1000).then(poll);
+            });
+        };
+
+        return Promise.all([poll(), worker.run()]);
+      })
+      .spread(state => expect(state).to.eql('complete'));
+  });
+
+  it('can forcefully quit workers', () => {
+    return Promise.all([
+      worker.run(),
+      Promise.delay(50).then(() => worker.stop(true)),
+    ]);
+  });
+
+  it('respawns workers that die', () => {
+    const getPids = () => worker.pool.workers.map(poolWorker => poolWorker.worker.pid);
+    const busyWaitPid = (pid) => {
+      try {
+        // Killing a process with signal 0 is a way to check if a process exists
+        return Promise.resolve(process.kill(pid, 0))
+          .delay(100)
+          .then(() => busyWaitPid(pid));
+      } catch (err) {
+        return Promise.resolve(pid);
+      }
+    };
+    const checkRespawn = () => {
+      const original = getPids();
+
+      // Destroy all the worker processes
+      original.forEach((pid) => {
+        process.kill(pid);
+      });
+
+      // Wait for the worker processes to be killed and then check what the
+      // replacement pids are
+      return Promise.map(original, busyWaitPid)
+        .then(() => {
+          const replacements = getPids();
+
+          expect(replacements.length).to.eql(original.length);
+          expect(replacements).not.to.eql(original);
+        })
+        .then(() => worker.stop());
+    };
+
+    return Promise.all([worker.run(), checkRespawn()]);
+  });
+});

--- a/test/workers/job.js
+++ b/test/workers/job.js
@@ -1,0 +1,11 @@
+'use strict';
+
+class BasicJob {
+  static process(job) {
+    return job.complete();
+  }
+}
+
+module.exports = {
+  BasicJob,
+};

--- a/test/workers/multi.test.js
+++ b/test/workers/multi.test.js
@@ -19,7 +19,8 @@ describe('Multi Worker', () => {
   let worker = null;
 
   beforeEach(() => {
-    worker = new Worker(client, {
+    worker = new Worker({
+      client,
       queues: [queue],
       interval,
       count: capacity,
@@ -32,8 +33,23 @@ describe('Multi Worker', () => {
   afterAll(() => client.quit());
 
   it('uses default interval', () => {
-    worker = new Worker(client, { count: capacity });
+    worker = new Worker({
+      client,
+      count: capacity,
+      queueNames: ['queue'],
+    });
     expect(worker.interval).to.eql(60000);
+  });
+
+  it('can accept a client config', () => {
+    worker = new Worker({
+      clientConfig: {
+        url,
+      },
+      count: capacity,
+      queueNames: [],
+    });
+    worker.client.quit();
   });
 
   it('can run jobs', () => {

--- a/test/workers/single.test.js
+++ b/test/workers/single.test.js
@@ -18,7 +18,8 @@ describe('Single Worker', () => {
   let worker = null;
 
   beforeEach(() => {
-    worker = new Worker(client, {
+    worker = new Worker({
+      client,
       queues: [queue],
       interval,
     });
@@ -30,7 +31,20 @@ describe('Single Worker', () => {
   afterAll(() => client.quit());
 
   it('uses default interval', () => {
-    expect(new Worker(client, {}).interval).to.eql(60000);
+    expect(new Worker({
+      client,
+      queueNames: ['queue'],
+    }).interval).to.eql(60000);
+  });
+
+  it('can accept a client config', () => {
+    worker = new Worker({
+      clientConfig: {
+        url,
+      },
+      queueNames: [],
+    });
+    worker.client.quit();
   });
 
   it('can run jobs', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,7 +1865,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2627,6 +2627,12 @@ worker-farm@^1.3.1:
   dependencies:
     errno ">=0.1.1 <0.2.0-0"
     xtend ">=4.0.0 <4.1.0-0"
+
+workerpool@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.0.tgz#86c5cbe946b55e7dc9d12b1936c8801a6e2d744d"
+  dependencies:
+    object-assign "4.1.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Like the `qless-py` counterpart, this spawns up several subprocesses that each run a worker. Each spawned worker runs up to a certain number of jobs concurrently, so if started with `--processes=n --concurrency=m`, a total of `nm` jobs would be run concurrently on that machine.

It responds to `SIGQUIT` to gracefully exit, allowing all running work to finish before exiting, and for `SIGTERM` and the like, it forcefully stops everything it its tracks.

@kqiu @evanbattaglia @b4hand 