### PR TITLE
Add `job.when()`

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -345,6 +345,18 @@ class Job extends BaseJob {
     return this.client.call('timeout', this.jid);
   }
 
+  /**
+   * If the job is in the `scheduled` state, return a promise that resolves to when
+   * it's scheduled to run in seconds since epoch. Otherwise, return a promise
+   * that resolves to null.
+   */
+  when() {
+    if (this.state === 'scheduled') {
+      return this.client.redis.zscoreAsync(`ql:q:${this.queueName}-scheduled`, this.jid);
+    }
+    return Promise.resolve(null);
+  }
+
 }
 
 class RecurringJob extends BaseJob {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",

--- a/test/job.test.js
+++ b/test/job.test.js
@@ -169,6 +169,28 @@ describe('Job', () => {
       });
   });
 
+  it('can get when() for a scheduled job', () => {
+    const jid = 'jid';
+    const delay = 10;
+    return queue.put({ klass: 'Klass', jid, delay })
+      .then(() => client.job(jid))
+      .then(job => job.when())
+      .then((when) => {
+        const now = (new Date()).getTime() / 1000.0;
+        const diff = Math.abs(when - delay - now);
+
+        expect(diff).to.be.below(1);
+      });
+  });
+
+  it('cannot get when() for a non-scheduled job', () => {
+    const jid = 'jid';
+    return queue.put({ klass: 'Klass', jid })
+      .then(() => client.job(jid))
+      .then(job => job.when())
+      .then((when) => expect(when).to.eql(null));
+  });
+
   it('can complete', () => {
     return queue.put({ klass: 'Klass' })
       .then(() => queue.pop())


### PR DESCRIPTION
For scheduled jobs, it's useful to be able to know for when they're scheduled.

@evanbattaglia @b4hand @kq2