### PR TITLE
call out `--processes` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ order). Only when there are no jobs available does the worker sleep for the
 provided interval before checking again. Otherwise, immediately after completing
 a job, it checks for another.
 
+### Number of processes (`--processes`)
+
+This configures the number of processes that qless will spawn.  It
+defaults to the number of cores on the machine.
+
 ### Multiple queues (`--queue`)
 
 A worker can grab jobs from multiple queues, as they're available. They're


### PR DESCRIPTION
When using qless-js in a docker container (which is run on a host that has 32 cores), qless was trying to fork 32 workers, which was causing issues on the docker host.  I was unaware that `--processes` existed until I dug around the code.

Calling this arg out in the README would be beneficial.