### PR TITLE
Ensure jobs.tagged returns jobs as an array

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -28,7 +28,11 @@ class Jobs {
 
   tagged(tag, offset, count) {
     return this.client.call('tag', 'get', tag, offset || 0, count || 25)
-      .then(JSON.parse);
+      .then(JSON.parse)
+      .then((response) => {
+        response.jobs = asArray(response.jobs);
+        return response;
+      });
   }
 
   get(...jids) {

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -88,6 +88,12 @@ describe('Jobs', () => {
         .get('jobs')
         .then(jobs => expect(new Set(jobs)).to.eql(new Set(jids)));
     });
+
+    it('provides jobs as an array when empty', () => {
+      return client.jobs.tagged('other-tag')
+        .get('jobs')
+        .then(jobs => expect(jobs).to.be.an('array'));
+    });
   });
 
   describe('get', () => {


### PR DESCRIPTION
Yet another instance where an empty lua `table` comes back serialized as `{}` rather than `[]`. In this case, the returned `jobs` is meant to always be an array.

If we merge this one before https://github.com/seomoz/qless-js/pull/36, we could have a single version bump for both changes.