### PR TITLE
Expose `dependents` and `dependencies` as an array

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -5,6 +5,7 @@ const workerpool = require('workerpool');
 const Promise = require('bluebird').Promise;
 const Path = require('path');
 const logger = require('./logger.js');
+const asArray = require('./util.js').asArray;
 
 class BaseJob {
 
@@ -37,8 +38,8 @@ class Job extends BaseJob {
     this.tracked = config.tracked;
     this.failure = config.failure;
     this.history = config.history;
-    this.dependents = config.dependents;
-    this.dependencies = config.dependencies;
+    this.dependents = asArray(config.dependents);
+    this.dependencies = asArray(config.dependencies);
     this.expiresAt = config.expires;
     this.originalRetries = config.retries;
     this.retriesLeft = config.remaining;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",

--- a/test/job.test.js
+++ b/test/job.test.js
@@ -42,6 +42,52 @@ describe('Job', () => {
       });
   });
 
+  describe('dependents', () => {
+    const dependee = 'first';
+    const dependent = 'second';
+
+    beforeEach(() => {
+      const config = {
+        klass: 'Klass',
+        data: {},
+      };
+      return queue.put(Object.assign({ jid: dependee }, config))
+        .then(() => queue.put(Object.assign({ jid: dependent, depends: [dependee] }, config)));
+    });
+
+    it('can access dependents as an array when it has them', () => {
+      return client.job(dependee)
+        .then((job) => {
+          expect(job.dependents).to.be.an(Array);
+          expect(job.dependents).to.eql([dependent]);
+        });
+    });
+
+    it('can access dependents as an array when it has none', () => {
+      return client.job(dependent)
+        .then((job) => {
+          expect(job.dependents).to.be.an(Array);
+          expect(job.dependents).to.eql([]);
+        });
+    });
+
+    it('can access dependencies as an array when it has them', () => {
+      return client.job(dependent)
+        .then((job) => {
+          expect(job.dependencies).to.be.an(Array);
+          expect(job.dependencies).to.eql([dependee]);
+        });
+    });
+
+    it('can access dependencies as an array when it has none', () => {
+      return client.job(dependee)
+        .then((job) => {
+          expect(job.dependencies).to.be.an(Array);
+          expect(job.dependencies).to.eql([]);
+        });
+    });
+  });
+
   it('can import a file', () => {
     const path = Path.resolve(__dirname, '../lib/client.js');
     expect(Job.import(path)).to.eql(Client);


### PR DESCRIPTION
Bitten again by the `lua` JSON serializer converting empty tables to objects, this ensures that `job.dependents` and `job.dependencies` are both always arrays.