### PR TITLE
Add `job.log`

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -295,6 +295,13 @@ class Job extends BaseJob {
       'fail', this.jid, this.client.workerName, group, message, JSON.stringify(this.data));
   }
 
+  /**
+   * Pass in a message and an optional object of other attributes to log.
+   */
+  log(message, data) {
+    return this.client.call('log', this.jid, message, JSON.stringify(data || {}));
+  }
+
   track() {
     return this.client.call('track', 'track', this.jid);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",

--- a/test/job.test.js
+++ b/test/job.test.js
@@ -298,6 +298,33 @@ describe('Job', () => {
       });
   });
 
+  it('can log for a job with extra data', () => {
+    const jid = 'jid';
+    return queue.put({ klass: 'Klass', jid })
+      .then(() => client.job(jid))
+      .then(job => job.log('message', { attribute: 'value' }))
+      .then(() => client.job(jid))
+      .then((job) => {
+        const entry = job.history[job.history.length - 1];
+
+        expect(entry.what).to.eql('message');
+        expect(entry.attribute).to.eql('value');
+      });
+  });
+
+  it('can log for a job without extra data', () => {
+    const jid = 'jid';
+    return queue.put({ klass: 'Klass', jid })
+      .then(() => client.job(jid))
+      .then(job => job.log('message'))
+      .then(() => client.job(jid))
+      .then((job) => {
+        const entry = job.history[job.history.length - 1];
+
+        expect(entry.what).to.eql('message');
+      });
+  });
+
   it('can track and untrack a job', () => {
     const jid = 'jid';
     return queue.put({ klass: 'Klass', jid })


### PR DESCRIPTION
The `job.log` method allows users to inject logs into the job processing history.

@evanbattaglia @lindseyreno