### PR TITLE
Add support for job.workdir

### DIFF
--- a/bin/qless-js-worker.js
+++ b/bin/qless-js-worker.js
@@ -1,7 +1,9 @@
 #! /usr/bin/env node
 
-const assert = require('assert');
 const os = require('os');
+const Path = require('path');
+
+const assert = require('assert');
 const qless = require('../index.js');
 
 const commander = require('commander');
@@ -49,6 +51,7 @@ const config = {
   processConfig: {
     allowPaths: options.allowPaths,
   },
+  workdir: options.workdir || Path.join(os.tmpdir(), 'qless'),
   processes: options.processes,
   logLevel: qless.logger.level,
 };

--- a/bin/qless-js.js
+++ b/bin/qless-js.js
@@ -140,7 +140,7 @@ const cancel = (jids, options) => {
  * Unrecur one recurring jobs
  */
 const unrecur = (jid) => {
-  logWithClient((client) => client.call('unrecur', jid));
+  logWithClient(client => client.call('unrecur', jid));
 };
 
 /**

--- a/lib/workers/forking.js
+++ b/lib/workers/forking.js
@@ -57,6 +57,8 @@ class Worker {
 
       const config = deepCopy(this.config);
 
+      config.workdir = Path.join(this.config.workdir, `${id}`);
+
       if (this.stopped) {
         return id;
       }

--- a/lib/workers/multi.js
+++ b/lib/workers/multi.js
@@ -1,9 +1,15 @@
 'use strict';
 
+const Path = require('path');
+
 const Promise = require('bluebird').Promise;
+const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
+
 const Popper = require('./popper.js');
 const Semaphore = require('./semaphore.js');
 const Client = require('../client.js');
+const logger = require('../logger.js');
 
 /**
  * Worker that runs multiple concurrent jobs.
@@ -18,6 +24,12 @@ class Worker {
     this.processConfig = config.processConfig;
     this.semaphore = new Semaphore(config.count);
     this.running = new Set();
+    this.workdir = config.workdir;
+  }
+
+  cleanWorkDir(directory) {
+    logger.warn(`Cleaning ${directory}...`);
+    rimraf.sync(this.workdir);
   }
 
   /**
@@ -57,11 +69,19 @@ class Worker {
    * is an unrecoverable exception.
    */
   run() {
+    this.cleanWorkDir(this.workdir);
+
     return this.semaphore.acquire()
       .then(() => this.pop())
       .then((job) => {
         // Bail and wait for all running promises
         if (!job) return Promise.all(this.running);
+
+        const jobWorkdir = Path.join(this.workdir, job.jid);
+
+        mkdirp.sync(jobWorkdir);
+
+        job.workdir = jobWorkdir;
 
         const process = job.process(this.processConfig);
         this.running.add(process);
@@ -69,6 +89,7 @@ class Worker {
           .finally(() => {
             this.semaphore.release();
             this.running.delete(process);
+            this.cleanWorkDir(jobWorkdir);
           });
 
         // Try to run another job, waiting on the semaphore.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",
@@ -42,7 +42,9 @@
     "double-ended-queue": "^2.1.0-0",
     "es6-error": "^4.0.2",
     "json-stable-stringify": "^1.0.1",
+    "mkdirp": "^1.0.4",
     "redis": "^2.7.1",
+    "rimraf": "^3.0.2",
     "uuid": "^3.0.1",
     "winston": "^2.3.1",
     "workerpool": "^2.3.0"

--- a/test/workers/forking.test.js
+++ b/test/workers/forking.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const os = require('os');
 const Path = require('path');
 
 const Promise = require('bluebird').Promise;
@@ -30,6 +31,7 @@ describe('Forking Worker', () => {
       interval,
       count: capacity,
       processes: 2,
+      workdir: Path.join(os.tmpdir(), 'qless'),
     });
     return cleaner.before();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,6 +300,11 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -321,6 +326,14 @@ brace-expansion@^1.0.0:
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
   dependencies:
     balanced-match "^0.4.1"
+    concat-map "0.0.1"
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -1025,6 +1038,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -1782,6 +1807,13 @@ minimatch@^3.0.2, minimatch@^3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -1795,6 +1827,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 ms@0.7.1:
   version "0.7.1"
@@ -2213,6 +2250,13 @@ rimraf@^2.2.8, rimraf@^2.4.4:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
 run-async@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Other language bindings include a `job.workdir` while processing a job that provides a workspace that is guaranteed to be clean before the job runs, and cleaned up after the job runs. The worker also guarantees that the workspace is cleaned up when starting up, which helps in the event that the worker completely crashes.

This seeks to add that functionality here.