### PR TITLE
Remove unnecessary preinstall step

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "lint": "eslint --ext .js bin lib test",
     "test": "jest --runInBand",
-    "preinstall": "git submodule update --init --recursive && make -C lib/qless-core clean all",
     "prepublish": "git submodule update --init --recursive && make -C lib/qless-core clean all"
   },
   "repository": {


### PR DESCRIPTION
This was for a temporary stopgap, but I think it would introduce an unnecessary dependency for users of this library.