### PR TITLE
Fixes premature workdir deletion bug

### DIFF
--- a/lib/workers/multi.js
+++ b/lib/workers/multi.js
@@ -28,9 +28,10 @@ class Worker {
     this.setTmpdir = config.setTmpdir;
   }
 
+  // eslint-disable-next-line class-methods-use-this
   cleanWorkDir(directory) {
-    logger.warn(`Cleaning ${directory}...`);
-    rimraf.sync(this.workdir);
+    logger.info(`Cleaning ${directory}...`);
+    rimraf.sync(directory);
   }
 
   /**
@@ -71,7 +72,10 @@ class Worker {
    */
   run() {
     this.cleanWorkDir(this.workdir);
+    return this.doRun();
+  }
 
+  doRun() {
     mkdirp.sync(this.workdir);
 
     if (this.setTmpdir) {
@@ -100,7 +104,7 @@ class Worker {
           });
 
         // Try to run another job, waiting on the semaphore.
-        return this.run();
+        return this.doRun();
       });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qless-js",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": false,
   "description": "Qless JavaScript Bindings",
   "main": "index.js",


### PR DESCRIPTION
In cases where --concurrency>1 is used /and/ the qless workdir, there
was a bug in which the working directory was overeagerly cleaned,
leading to job failures. This fixes that issue by /only/ cleaning the
process working directory at first run time.

Releases 0.4.8

cc @a1ph4g33k @evanbattaglia @lindseyreno